### PR TITLE
Enhancement/11 delete labresults

### DIFF
--- a/APIChallenge.Tests/LabResultControllerTests.cs
+++ b/APIChallenge.Tests/LabResultControllerTests.cs
@@ -35,6 +35,9 @@ namespace APIDevelopmentChallenge.Tests
                 MeasurementUnit = "Unit"
             };
 
+            // Make sure patient can be found for verification
+            patients.Add(newLabResult.Patient);
+
             controller.Post(newLabResult);
 
             Assert.Equal(labResultCount + 1, repo.InternalData.Count);
@@ -111,12 +114,12 @@ namespace APIDevelopmentChallenge.Tests
         }
 
         [Fact]
-        public void Put_Method_Updates_A_Patient()
+        public void Put_Method_Updates_A_LabResult()
         {
             var labResultId = 99;
             var patients = CreateTestPatients(5);
             var labResults = CreateTestLabResults(5);
-            patients[0].Id = labResultId;
+            labResults[0].Id = labResultId;
 
             var repo = new InMemoryLabResultRepository(labResults);
             var patientRepo = new InMemoryPatientRepository(patients);
@@ -136,6 +139,9 @@ namespace APIDevelopmentChallenge.Tests
                 MeasurementUnit = "Unit"
             };
 
+            // Make sure patient can be found for verification
+            patients.Add(labResultToUpdate.Patient);
+
             controller.Put(labResultId, labResultToUpdate);
 
             var labResultFromDb = repo.InternalData.FirstOrDefault(lr => lr.Id == labResultId);
@@ -150,6 +156,24 @@ namespace APIDevelopmentChallenge.Tests
             Assert.Equal(labResultToUpdate.OrderedByProvider, labResultFromDb.OrderedByProvider);
             Assert.Equal(labResultToUpdate.Measurement, labResultFromDb.Measurement);
             Assert.Equal(labResultToUpdate.MeasurementUnit, labResultFromDb.MeasurementUnit);
+        }
+
+        [Fact]
+        public void Delete_Method_Removes_A_LabResult()
+        {
+            var labResultId = 99;
+            var labResults = CreateTestLabResults(5);
+            var patients = CreateTestPatients(5);
+            labResults[0].Id = labResultId;
+
+            var repo = new InMemoryLabResultRepository(labResults);
+            var patientRepo = new InMemoryPatientRepository(patients);
+            var controller = new LabResultController(repo, patientRepo);
+
+            controller.Delete(labResultId);
+
+            var labResultFromDb = repo.InternalData.FirstOrDefault(p => p.Id == labResultId);
+            Assert.Null(labResultFromDb);
         }
 
         private LabResultController CreateController(List<LabResult> labResults, List<Patient> patients)

--- a/APIChallenge.Tests/Mocks/InMemoryLabResultRepository.cs
+++ b/APIChallenge.Tests/Mocks/InMemoryLabResultRepository.cs
@@ -58,6 +58,16 @@ namespace APIDevelopmentChallenge.Tests.Mocks
             currentLabResult.Measurement = labResult.Measurement;
             currentLabResult.MeasurementUnit = labResult.MeasurementUnit;
         }
+        public void Delete(int id)
+        {
+            var labResultToDelete = _data.FirstOrDefault(lr => lr.Id == id);
+            if (labResultToDelete == null)
+            {
+                return;
+            }
+
+            _data.Remove(labResultToDelete);
+        }
 
     }
 }

--- a/APIDevelopmentChallenge/Controllers/LabResultController.cs
+++ b/APIDevelopmentChallenge/Controllers/LabResultController.cs
@@ -97,6 +97,22 @@ namespace APIDevelopmentChallenge.Controllers
             return NoContent();
         }
 
+        [HttpDelete("{id}")]
+        public IActionResult Delete(int id)
+        {
+            try
+            {
+                _labResultRepository.Delete(id);
+            }
+            catch
+            {
+                return StatusCode(500, "Internal error -- Unable to delete patient");
+            }
+
+            return NoContent();
+        }
+
+
         private static string ValidateData(LabResult labResult, Patient patient)
         {
             if (patient == null)

--- a/APIDevelopmentChallenge/Controllers/LabResultController.cs
+++ b/APIDevelopmentChallenge/Controllers/LabResultController.cs
@@ -78,15 +78,16 @@ namespace APIDevelopmentChallenge.Controllers
             {
                 return BadRequest("LabResult Id does not match route");
             }
-            var patient = _patientRepository.GetById(labResult.PatientId);
-            var errorMessage = ValidateData(labResult, patient);
-            if (!String.IsNullOrEmpty(errorMessage))
-            {
-                return BadRequest(errorMessage);
-            }
-
             try
             {
+
+                var patient = _patientRepository.GetById(labResult.PatientId);
+                var errorMessage = ValidateData(labResult, patient);
+                if (!String.IsNullOrEmpty(errorMessage))
+                {
+                    return BadRequest(errorMessage);
+                }
+
                 _labResultRepository.Update(labResult);
             }
             catch (Exception e)

--- a/APIDevelopmentChallenge/Repositories/ILabResultRepository.cs
+++ b/APIDevelopmentChallenge/Repositories/ILabResultRepository.cs
@@ -9,5 +9,6 @@ namespace APIDevelopmentChallenge.Repositories
         LabResult GetById(int id);
         List<LabResult> GetByPatientId(int id);
         void Update(LabResult labResult);
+        void Delete(int id);
     }
 }

--- a/APIDevelopmentChallenge/Repositories/LabResultRepository.cs
+++ b/APIDevelopmentChallenge/Repositories/LabResultRepository.cs
@@ -146,6 +146,25 @@ namespace APIDevelopmentChallenge.Repositories
             }
         }
 
+        /// <summary>
+        /// Method to remove a lab result from the database
+        /// </summary>
+        /// <param name="id">Id of the lab result to be removed</param>
+        public void Delete(int id)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = "DELETE FROM LabResult WHERE Id=@Id;";
+                    DbUtils.AddParameter(cmd, "@Id", id);
+
+                    cmd.ExecuteNonQuery();
+                }
+            }
+        }
 
         private LabResult NewLabResultFromDb(SqlDataReader reader)
         {

--- a/APIDevelopmentChallenge/Repositories/PatientRepository.cs
+++ b/APIDevelopmentChallenge/Repositories/PatientRepository.cs
@@ -158,7 +158,8 @@ namespace APIDevelopmentChallenge.Repositories
 
                 using (var cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = "DELETE FROM Patient WHERE Id=@Id;";
+                    cmd.CommandText = @"DELETE FROM LabResult WHERE PatientId=@Id;
+                                        DELETE FROM Patient WHERE Id=@Id;";
                     DbUtils.AddParameter(cmd, "@Id", id);
 
                     cmd.ExecuteNonQuery();


### PR DESCRIPTION
# Description
Created a DELETE route for users to remove lab results.

Also fixed two bugs:
- If a patient record had lab results in the database, that patient could not be deleted. Now, any attached lab results are deleted prior to patient deletion.
- Fixed issues in the tests for the LabResult POST and PUT routes that caused test failure.

Fixes #11 

## Type of Change
Enhancement

## Testing Steps
1. Start the application
2. Execute the DELETE route for the LabResult controller using an existing Id
3. Verify deletion via one of the GET routes
