### PR TITLE
Add route to get patients by lab results

### DIFF
--- a/APIChallenge.Tests/Mocks/InMemoryPatientRepository.cs
+++ b/APIChallenge.Tests/Mocks/InMemoryPatientRepository.cs
@@ -2,12 +2,15 @@
 using APIDevelopmentChallenge.Models;
 using APIDevelopmentChallenge.Repositories;
 using System.Linq;
+using System;
 
 namespace APIDevelopmentChallenge.Tests.Mocks
 {
     class InMemoryPatientRepository : IPatientRepository
     {
         private readonly List<Patient> _data;
+        private readonly List<LabResult> _labResultData;
+
         public List<Patient> InternalData
         {
             get
@@ -19,6 +22,7 @@ namespace APIDevelopmentChallenge.Tests.Mocks
         public InMemoryPatientRepository(List<Patient> startingData)
         {
             _data = startingData;
+            _labResultData = CreateTestLabResults(_data.Count);
         }
 
         public void Add(Patient patient)
@@ -64,6 +68,34 @@ namespace APIDevelopmentChallenge.Tests.Mocks
             }
 
             _data.Remove(patientToDelete);
+        }
+
+        public List<Patient> GetByLabs(string query, DateTime startDate, DateTime endDate)
+        {
+            var matchingLabResults = _labResultData.Where(lr => lr.TestType == query && lr.TimeOfTest > startDate && lr.TimeOfTest < endDate).ToList();
+            var patientIds = matchingLabResults.Select(mlr => mlr.PatientId).ToList();
+            return _data.Where(p => patientIds.Contains(p.Id)).ToList();
+        }
+
+        private List<LabResult> CreateTestLabResults(int count)
+        {
+            var labResults = new List<LabResult>();
+            for (var i = 1; i <= count; i++)
+            {
+                labResults.Add(new LabResult()
+                {
+                    Id = i,
+                    TestType = i % 2 == 0 ? "TestType-2" : "TestType-1",
+                    Result = $"Result {i}",
+                    PatientId = i,
+                    TimeOfTest = DateTime.Now.AddDays(-i),
+                    LabName = $"LabName {i}",
+                    OrderedByProvider = $"OrderedByProvider {i}",
+                    Measurement = 1 / i,
+                    MeasurementUnit = $"Unit {i}"
+                });
+            }
+            return labResults;
         }
     }
 }

--- a/APIChallenge.Tests/PatientControllerTests.cs
+++ b/APIChallenge.Tests/PatientControllerTests.cs
@@ -156,6 +156,31 @@ namespace APIDevelopmentChallenge.Tests
             Assert.Null(patientFromDb);
         }
 
+        [Fact]
+        public void Query_Search_Returns_Matching_Results()
+        {
+            int itemCount = 20;
+            var patients = CreateTestPatients(itemCount);
+            var query1 = "TestType-1";
+            var query2 = "TestType-2";
+            var startDate = DateTime.Now.AddDays(-10);
+            var endDate = DateTime.Now.AddDays(-5);
+
+            var controller = CreateController(patients);
+            var result1 = controller.GetByLabs(query1, startDate, endDate);
+            var result2 = controller.GetByLabs(query2, startDate, endDate);
+
+            var OkObject1 = Assert.IsType<OkObjectResult>(result1);
+            var actualPatient1 = Assert.IsType<List<Patient>>(OkObject1.Value);
+
+            var OkObject2 = Assert.IsType<OkObjectResult>(result2);
+            var actualPatient2 = Assert.IsType<List<Patient>>(OkObject2.Value);
+
+            // Item 5 is not hit because LabResults are generated after the endDate query
+            Assert.Equal(2, actualPatient1.Count); // Items 7, 9
+            Assert.Equal(3, actualPatient2.Count); // Items 6, 8, 10
+        }
+
         private PatientController CreateController(List<Patient> patients)
         {
             var repo = new InMemoryPatientRepository(patients);

--- a/APIDevelopmentChallenge/Controllers/PatientController.cs
+++ b/APIDevelopmentChallenge/Controllers/PatientController.cs
@@ -92,5 +92,16 @@ namespace APIDevelopmentChallenge.Controllers
 
             return NoContent();
         }
+
+        [HttpGet("labs")]
+        public IActionResult GetByLabs(string query, DateTime startDate, DateTime endDate)
+        {
+            if (startDate > endDate)
+            {
+                return BadRequest("Invalid date range");
+            }
+
+            return Ok(_patientRepository.GetByLabs(query, startDate, endDate));
+        }
     }
 }

--- a/APIDevelopmentChallenge/Repositories/IPatientRepository.cs
+++ b/APIDevelopmentChallenge/Repositories/IPatientRepository.cs
@@ -1,4 +1,5 @@
 ﻿using APIDevelopmentChallenge.Models;
+using System;
 using System.Collections.Generic;
 
 namespace APIDevelopmentChallenge.Repositories
@@ -10,5 +11,6 @@ namespace APIDevelopmentChallenge.Repositories
         Patient GetById(int id);
         void Update(Patient patient);
         void Delete(int id);
+        List<Patient> GetByLabs(string query, DateTime startDate, DateTime endDate);
     }
 }


### PR DESCRIPTION
# Description
Created a route that allows a user to retrieve patients that have a certain type of lab result in a given datetime range.
The route uses the "/labs" path and takes three queries:
query: the TestType for the LabResult
startDate: the starting date of the datetime range
endDate: the end date of the datetime range

Fixes #12 

## Type of Change
Enhancement

## Testing Steps
1. Start the application
2. Make sure there is enough data in the database to make a successful search
3. Go to the GET route on the Patient controller, ```api/Patient/labs```
4. Enter a search query, startDate (```'mm-dd-yyyy'```), and endDate
5. Perform the search and verify that the expected results are returned
